### PR TITLE
Update provider, add gcp_filestore_csi_driver_config block, make variable optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Change `var.network` and `var.subnetwork` to be optional variables
+
 ## [0.0.3]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add support for `gcp_filestore_csi_driver_config` block
+
 ### Changed
 
 - Turn `var.location` to be optional
 - Change `var.network` and `var.subnetwork` to be optional variables
+- Change minimum required version of google provider to `v4.10.0`
 
 ## [0.0.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Turn `var.location` to be optional
 - Change `var.network` and `var.subnetwork` to be optional variables
 
 ## [0.0.3]

--- a/README.md
+++ b/README.md
@@ -74,9 +74,14 @@ See [variables.tf] and [examples/] for details and use-cases.
 
   The name of the cluster.
 
-- [**`location`**](#var-location): *(**Required** `string`)*<a name="var-location"></a>
+- [**`location`**](#var-location): *(Optional `string`)*<a name="var-location"></a>
 
-  The location (region or zone) in which the cluster master will be created.
+  The location (region or zone) in which the cluster master will be
+  created, as well as the default node location. If you specify a zone
+  (such as `us-central1-a`), the cluster will be a zonal cluster with
+  a single cluster master. If you specify a region (such as `us-west1`),
+  the cluster will be a regional cluster with multiple masters spread
+  across zones in the region, and with default node locations in those zones as well.
   For the differences between zonal and regional clusters, please see
   https://cloud.google.com/kubernetes-engine/docs/concepts/types-of-clusters
 

--- a/README.md
+++ b/README.md
@@ -80,13 +80,13 @@ See [variables.tf] and [examples/] for details and use-cases.
   For the differences between zonal and regional clusters, please see
   https://cloud.google.com/kubernetes-engine/docs/concepts/types-of-clusters
 
-- [**`network`**](#var-network): *(**Required** `string`)*<a name="var-network"></a>
+- [**`network`**](#var-network): *(Optional `string`)*<a name="var-network"></a>
 
   The name or `self_link` of the Google Compute Engine network to which
   the cluster is connected. For Shared VPC, set this to the self link of
   the shared network.
 
-- [**`subnetwork`**](#var-subnetwork): *(**Required** `string`)*<a name="var-subnetwork"></a>
+- [**`subnetwork`**](#var-subnetwork): *(Optional `string`)*<a name="var-subnetwork"></a>
 
   The name or `self_link` of the Google Compute Engine subnetwork in which
   the cluster's instances are launched.

--- a/README.md
+++ b/README.md
@@ -260,6 +260,19 @@ See [variables.tf] and [examples/] for details and use-cases.
 
   Default is `false`.
 
+- [**`addon_network_policy_config`**](#var-addon_network_policy_config): *(Optional `bool`)*<a name="var-addon_network_policy_config"></a>
+
+  Whether to enable the network policy addon.
+
+  Default is `false`.
+
+- [**`addon_filestore_csi_driver`**](#var-addon_filestore_csi_driver): *(Optional `bool`)*<a name="var-addon_filestore_csi_driver"></a>
+
+  Whether to enable the Filestore CSI driver addon, which allows the
+  usage of filestore instance as volumes.
+
+  Default is `false`.
+
 - [**`addon_cloudrun_config`**](#var-addon_cloudrun_config): *(Optional `bool`)*<a name="var-addon_cloudrun_config"></a>
 
   Whether to enable the network policy addon.

--- a/README.tfdoc.hcl
+++ b/README.tfdoc.hcl
@@ -100,10 +100,14 @@ section {
       }
 
       variable "location" {
-        required    = true
         type        = string
         description = <<-END
-          The location (region or zone) in which the cluster master will be created.
+          The location (region or zone) in which the cluster master will be
+          created, as well as the default node location. If you specify a zone
+          (such as `us-central1-a`), the cluster will be a zonal cluster with
+          a single cluster master. If you specify a region (such as `us-west1`),
+          the cluster will be a regional cluster with multiple masters spread
+          across zones in the region, and with default node locations in those zones as well.
           For the differences between zonal and regional clusters, please see
           https://cloud.google.com/kubernetes-engine/docs/concepts/types-of-clusters
         END

--- a/README.tfdoc.hcl
+++ b/README.tfdoc.hcl
@@ -110,7 +110,6 @@ section {
       }
 
       variable "network" {
-        required    = true
         type        = string
         description = <<-END
           The name or `self_link` of the Google Compute Engine network to which
@@ -120,7 +119,6 @@ section {
       }
 
       variable "subnetwork" {
-        required    = true
         type        = string
         description = <<-END
           The name or `self_link` of the Google Compute Engine subnetwork in which

--- a/README.tfdoc.hcl
+++ b/README.tfdoc.hcl
@@ -335,6 +335,23 @@ section {
         END
       }
 
+      variable "addon_network_policy_config" {
+        type        = bool
+        default     = false
+        description = <<-END
+          Whether to enable the network policy addon.
+        END
+      }
+
+      variable "addon_filestore_csi_driver" {
+        type        = bool
+        default     = false
+        description = <<-END
+          Whether to enable the Filestore CSI driver addon, which allows the
+          usage of filestore instance as volumes.
+        END
+      }
+
       variable "addon_cloudrun_config" {
         type        = bool
         default     = false

--- a/main.tf
+++ b/main.tf
@@ -171,6 +171,10 @@ resource "google_container_cluster" "cluster" {
       disabled = !var.addon_network_policy_config
     }
 
+    gcp_filestore_csi_driver_config {
+      enabled = var.addon_filestore_csi_driver
+    }
+
     cloudrun_config {
       disabled = !var.addon_cloudrun_config
     }

--- a/test/unit-minimal/main.tf
+++ b/test/unit-minimal/main.tf
@@ -15,17 +15,25 @@ variable "region" {
   default     = "europe-west3"
 }
 
+variable "zone" {
+  type        = string
+  description = "(Optional) The GCP region zone to create all resources in."
+  default     = "europe-west3-a"
+}
+
 terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "4.1.0"
+      version = "4.10.0"
     }
   }
 }
 
 provider "google" {
   project = var.project
+  region  = var.region
+  zone    = var.zone
 }
 
 # Networking
@@ -87,13 +95,11 @@ module "test" {
   source = "../.."
 
   # add only required arguments and no optional arguments
-  name     = "gke-unit-minimal"
-  location = "${var.region}-a"
-  node_locations = [
-    "${var.region}-b",
-  ]
-  network                = module.vpc.vpc.self_link
-  subnetwork             = module.subnetwork.subnetworks["${var.region}/${local.subnet.name}"].self_link
+  name       = "gke-unit-minimal"
+  network    = module.vpc.vpc.self_link
+  subnetwork = module.subnetwork.subnetworks["${var.region}/${local.subnet.name}"].self_link
+
+  # deploy a public cluster with routes based networking mode
   networking_mode        = "VPC_NATIVE"
   master_ipv4_cidr_block = "10.4.96.0/28"
   ip_allocation_policy = {

--- a/variables.tf
+++ b/variables.tf
@@ -57,7 +57,7 @@ variable "addon_cloudrun_config" {
 
 variable "location" {
   type        = string
-  description = "(Optional) The location (region or zone) in which the cluster master will be created, as well as the default node location. If you specify a zone (such as us-central1-a), the cluster will be a zonal cluster with a single cluster master. If you specify a region (such as us-west1), the cluster will be a regional cluster with multiple masters spread across zones in the region, and with default node locations in those zones as well."
+  description = "(Optional) The location (region or zone) in which the cluster master will be created, as well as the default node location. If you specify a zone (such as 'us-central1-a'), the cluster will be a zonal cluster with a single cluster master. If you specify a region (such as us-west1), the cluster will be a regional cluster with multiple masters spread across zones in the region, and with default node locations in those zones as well."
   default     = null
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -8,20 +8,22 @@ variable "name" {
   description = "(Required) The name of the cluster."
 }
 
-variable "network" {
-  type        = string
-  description = "(Required) The name or 'self_link' of the Google Compute Engine network to which the cluster is connected. For Shared VPC, set this to the self link of the shared network."
-}
-
-variable "subnetwork" {
-  type        = string
-  description = "(Required) The name or 'self_link' of the Google Compute Engine subnetwork in which the cluster's instances are launched."
-}
-
 # ---------------------------------------------------------------------------------------------------------------------
 # OPTIONAL PARAMETERS
 # These variables have defauls, but may be overridden.
 # ----------------------------------------------------------------------------------------------------------------------
+
+variable "network" {
+  type        = string
+  description = "(Optional) The name or 'self_link' of the Google Compute Engine network to which the cluster is connected. For Shared VPC, set this to the self link of the shared network."
+  default     = null
+}
+
+variable "subnetwork" {
+  type        = string
+  description = "(Optional) The name or 'self_link' of the Google Compute Engine subnetwork in which the cluster's instances are launched."
+  default     = null
+}
 
 variable "project" {
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -49,6 +49,12 @@ variable "addon_network_policy_config" {
   default     = false
 }
 
+variable "addon_filestore_csi_driver" {
+  type        = bool
+  description = "(Optional) Whether to enable the Filestore CSI driver addon, which allows the usage of filestore instance as volumes."
+  default     = false
+}
+
 variable "addon_cloudrun_config" {
   type        = bool
   description = "(Optional) Whether to enable the CloudRun addon."

--- a/versions.tf
+++ b/versions.tf
@@ -6,6 +6,6 @@ terraform {
   required_version = ">= 0.14.7, < 2.0"
 
   required_providers {
-    google = "~> 4.1"
+    google = "~> 4.10.0"
   }
 }


### PR DESCRIPTION
- Change unit-minimal to deploy a routes based cluster
- Turn `var.location` to be optional
- Change `var.network` and `var.subnetwork` to be optional variables
- Change minimum required version of google provider to `v4.10.0`