### PR TITLE
Remove autoscaling for default node pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.5]
+
 ### Added
 
 - Added more comprehensive docs in README.md
@@ -78,7 +80,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial Implementation
 
-[unreleased]: https://github.com/mineiros-io/terraform-google-gke-cluster/compare/v0.0.4...HEAD
+[unreleased]: https://github.com/mineiros-io/terraform-google-gke-cluster/compare/v0.0.5...HEAD
+[0.0.5]: https://github.com/mineiros-io/terraform-google-gke-cluster/compare/v0.0.4...v0.0.5
 [0.0.4]: https://github.com/mineiros-io/terraform-google-gke-cluster/compare/v0.0.3...v0.0.4
 [0.0.3]: https://github.com/mineiros-io/terraform-google-gke-cluster/compare/v0.0.2...v0.0.3
 [0.0.2]: https://github.com/mineiros-io/terraform-google-gke-cluster/compare/v0.0.1...v0.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added more comprehensive docs in README.md
 
+### Removed
+
+- Removed `cluster_autoscaling` as it only applies to a clusters default node pool which are not supported by this module.
+
 ## [0.0.4]
 
 ### Added
@@ -79,5 +83,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.0.3]: https://github.com/mineiros-io/terraform-google-gke-cluster/compare/v0.0.2...v0.0.3
 [0.0.2]: https://github.com/mineiros-io/terraform-google-gke-cluster/compare/v0.0.1...v0.0.2
 [0.0.1]: https://github.com/mineiros-io/terraform-google-gke-cluster/releases/tag/v0.0.1
-
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added more comprehensive docs in README.md
+
 ## [0.0.4]
 
 ### Added
@@ -75,3 +79,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.0.3]: https://github.com/mineiros-io/terraform-google-gke-cluster/compare/v0.0.2...v0.0.3
 [0.0.2]: https://github.com/mineiros-io/terraform-google-gke-cluster/compare/v0.0.1...v0.0.2
 [0.0.1]: https://github.com/mineiros-io/terraform-google-gke-cluster/releases/tag/v0.0.1
+
+

--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ This module implements the following Terraform resources
 
 - `google_container_cluster`
 
+**Note:** This module comes without support for the default node pool
+or its autoscaling since it can't be managed properly with Terraform.
+Please use our [terraform-google-gke-node-pool](https://github.com/mineiros-io/terraform-google-gke-node-pool)
+module instead for deploying and managing node groups for your clusters.
+
 ## Getting Started
 
 Most common usage of the module:
@@ -76,11 +81,13 @@ See [variables.tf] and [examples/] for details and use-cases.
 - [**`location`**](#var-location): *(Optional `string`)*<a name="var-location"></a>
 
   The location (region or zone) in which the cluster master will be
-  created, as well as the default node location. If you specify a zone
-  (such as `us-central1-a`), the cluster will be a zonal cluster with
-  a single cluster master. If you specify a region (such as `us-west1`),
-  the cluster will be a regional cluster with multiple masters spread
-  across zones in the region, and with default node locations in those zones as well.
+  created, as well as the default node location.
+  If you specify a zone (such as `us-central1-a`), the cluster will be
+  a zonal cluster with a single cluster master.
+
+  If you specify a region (such as `us-west1`), the cluster will be a
+  regional cluster with multiple masters spread across zones in the
+  region, and with default node locations in those zones as well.
 
   For the differences between zonal and regional clusters, please see
   https://cloud.google.com/kubernetes-engine/docs/concepts/types-of-clusters
@@ -88,18 +95,21 @@ See [variables.tf] and [examples/] for details and use-cases.
 - [**`network`**](#var-network): *(Optional `string`)*<a name="var-network"></a>
 
   The name or `self_link` of the Google Compute Engine network to which
-  the cluster is connected. For Shared VPC, set this to the self link of
-  the shared network.
+  the cluster is connected.
+
+  **Note:** For Shared VPC, set this to the self link of the shared network.
 
 - [**`subnetwork`**](#var-subnetwork): *(Optional `string`)*<a name="var-subnetwork"></a>
 
-  The name or `self_link` of the Google Compute Engine subnetwork in which
-  the cluster's instances are launched.
+  The name or `self_link` of the Google Compute Engine subnetwork in
+  which the cluster's instances are launched.
 
 - [**`networking_mode`**](#var-networking_mode): *(Optional `string`)*<a name="var-networking_mode"></a>
 
   Determines whether alias IPs or routes will be used for pod IPs in
-  the cluster. Options are `VPC_NATIVE` or `ROUTES`. `VPC_NATIVE`
+  the cluster.
+
+  Options are `VPC_NATIVE` or `ROUTES`. `VPC_NATIVE`
   enables IP aliasing, and requires the `ip_allocation_policy` block to
   be defined.
 
@@ -245,8 +255,7 @@ See [variables.tf] and [examples/] for details and use-cases.
 
 - [**`enable_vertical_pod_autoscaling`**](#var-enable_vertical_pod_autoscaling): *(Optional `bool`)*<a name="var-enable_vertical_pod_autoscaling"></a>
 
-  If enabled, Vertical Pod Autoscaling automatically adjusts the
-  resources of pods controlled by it.
+  Whether to enable vertical Pod autoscaling in your cluster.
 
   For details please see https://cloud.google.com/kubernetes-engine/docs/concepts/verticalpodautoscaler
 
@@ -254,7 +263,7 @@ See [variables.tf] and [examples/] for details and use-cases.
 
 - [**`addon_horizontal_pod_autoscaling`**](#var-addon_horizontal_pod_autoscaling): *(Optional `bool`)*<a name="var-addon_horizontal_pod_autoscaling"></a>
 
-  Whether to enable orizontal Pod Autoscaling addon,
+  Whether to enable horizontal Pod Autoscaling addon,
   which increases or decreases the number of replica pods a
   replication controller has based on the resource usage of the existing pods.
 
@@ -445,7 +454,8 @@ See [variables.tf] and [examples/] for details and use-cases.
 - [**`resource_usage_export_bigquery_dataset_id`**](#var-resource_usage_export_bigquery_dataset_id): *(Optional `string`)*<a name="var-resource_usage_export_bigquery_dataset_id"></a>
 
   The ID of a BigQuery Dataset for using BigQuery as the destination of
-  resource usage export.
+  resource usage export. Needs to be configured when using egress metering
+  and/or resource consumption metering.
 
 - [**`enable_network_egress_metering`**](#var-enable_network_egress_metering): *(Optional `bool`)*<a name="var-enable_network_egress_metering"></a>
 
@@ -472,73 +482,6 @@ See [variables.tf] and [examples/] for details and use-cases.
   For details please see https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-usage-metering
 
   Default is `true`.
-
-- [**`cluster_autoscaling`**](#var-cluster_autoscaling): *(Optional `object(cluster_autoscaling)`)*<a name="var-cluster_autoscaling"></a>
-
-  Cluster autoscaling configuration. For details please see
-  https://cloud.google.com/kubernetes-engine/docs/concepts/cluster-autoscaler
-
-  Default is `false`.
-
-  The `cluster_autoscaling` object accepts the following attributes:
-
-  - [**`enabled`**](#attr-cluster_autoscaling-enabled): *(Optional `bool`)*<a name="attr-cluster_autoscaling-enabled"></a>
-
-    Whether node auto-provisioning is enabled. Resource limits for cpu
-    and memory must be defined to enable node auto-provisioning.
-
-    Default is `false`.
-
-  - [**`cpu`**](#attr-cluster_autoscaling-cpu): *(Optional `object(cpu)`)*<a name="attr-cluster_autoscaling-cpu"></a>
-
-    Global constraints for CPU machine resources in the cluster.
-    Configuring this is required if node auto-provisioning is enabled.
-    These limits will apply to node pool autoscaling in addition to
-    node auto-provisioning.
-
-    The `cpu` object accepts the following attributes:
-
-    - [**`minimum`**](#attr-cluster_autoscaling-cpu-minimum): *(Optional `number`)*<a name="attr-cluster_autoscaling-cpu-minimum"></a>
-
-      Minimum amount of CPU resources in the cluster.
-
-    - [**`maximum`**](#attr-cluster_autoscaling-cpu-maximum): *(Optional `number`)*<a name="attr-cluster_autoscaling-cpu-maximum"></a>
-
-      Maximum amount of CPU resources in the cluster.
-
-  - [**`memory`**](#attr-cluster_autoscaling-memory): *(Optional `object(memory)`)*<a name="attr-cluster_autoscaling-memory"></a>
-
-    Global constraints for Memory resources in the cluster. Configuring
-    this is required if node auto-provisioning is enabled. These limits
-    will apply to node pool autoscaling in addition to node auto-provisioning.
-
-    The `memory` object accepts the following attributes:
-
-    - [**`minimum`**](#attr-cluster_autoscaling-memory-minimum): *(Optional `number`)*<a name="attr-cluster_autoscaling-memory-minimum"></a>
-
-      Minimum amount of memory resources in the cluster.
-
-    - [**`maximum`**](#attr-cluster_autoscaling-memory-maximum): *(Optional `number`)*<a name="attr-cluster_autoscaling-memory-maximum"></a>
-
-      Maximum amount of memory resources in the cluster.
-
-  - [**`auto_provisioning_defaults`**](#attr-cluster_autoscaling-auto_provisioning_defaults): *(Optional `object(auto_provisioning_default)`)*<a name="attr-cluster_autoscaling-auto_provisioning_defaults"></a>
-
-    Contains defaults for a node pool created by NAP.
-
-    The `auto_provisioning_default` object accepts the following attributes:
-
-    - [**`oauth_scopes`**](#attr-cluster_autoscaling-auto_provisioning_defaults-oauth_scopes): *(Optional `list(string)`)*<a name="attr-cluster_autoscaling-auto_provisioning_defaults-oauth_scopes"></a>
-
-      Scopes that are used by NAP when creating node pools. Use the
-      https://www.googleapis.com/auth/cloud-platform scope to grant
-      access to all APIs. It is recommended that you set
-      `service_account` to a non-default service account and grant IAM
-      roles to that service account for only the resources that it needs.
-
-    - [**`service_account`**](#attr-cluster_autoscaling-auto_provisioning_defaults-service_account): *(Optional `string`)*<a name="attr-cluster_autoscaling-auto_provisioning_defaults-service_account"></a>
-
-      The Google Cloud Platform Service Account to be used by the node VMs.
 
 - [**`logging_enable_components`**](#var-logging_enable_components): *(Optional `set(string)`)*<a name="var-logging_enable_components"></a>
 
@@ -572,18 +515,26 @@ See [variables.tf] and [examples/] for details and use-cases.
   The GCE resource labels (a map of key/value pairs) to be applied to
   the cluster.
 
+  For details please see https://cloud.google.com/kubernetes-engine/docs/how-to/creating-managing-labels
+
   Default is `{}`.
 
 - [**`default_max_pods_per_node`**](#var-default_max_pods_per_node): *(Optional `number`)*<a name="var-default_max_pods_per_node"></a>
 
   The maximum number of pods to schedule per node.
+  GKE has a hard limit of 110 Pods per node.
 
   Default is `110`.
 
 - [**`enable_intranode_visibility`**](#var-enable_intranode_visibility): *(Optional `bool`)*<a name="var-enable_intranode_visibility"></a>
 
   Whether Intra-node visibility is enabled for this cluster.
-  This makes same node pod to pod traffic visible for VPC network.
+  Intranode visibility configures networking on each node in the
+  cluster so that traffic sent from one Pod to another Pod is
+  processed by the cluster's Virtual Private Cloud (VPC) network,
+  even if the Pods are on the same node.
+
+  For details please see https://cloud.google.com/kubernetes-engine/docs/how-to/intranode-visibility
 
   Default is `false`.
 
@@ -627,6 +578,7 @@ See [variables.tf] and [examples/] for details and use-cases.
 - [**`enable_shielded_nodes`**](#var-enable_shielded_nodes): *(Optional `bool`)*<a name="var-enable_shielded_nodes"></a>
 
   Whether to enable Shielded Nodes features on all nodes in this cluster.
+  For details please see https://cloud.google.com/kubernetes-engine/docs/concepts/release-channels
 
   Default is `true`.
 

--- a/README.tfdoc.hcl
+++ b/README.tfdoc.hcl
@@ -54,6 +54,11 @@ section {
       This module implements the following Terraform resources
 
       - `google_container_cluster`
+
+      **Note:** This module comes without support for the default node pool
+      or its autoscaling since it can't be managed properly with Terraform.
+      Please use our [terraform-google-gke-node-pool](https://github.com/mineiros-io/terraform-google-gke-node-pool)
+      module instead for deploying and managing node groups for your clusters.
     END
   }
 
@@ -102,11 +107,13 @@ section {
         type        = string
         description = <<-END
           The location (region or zone) in which the cluster master will be
-          created, as well as the default node location. If you specify a zone
-          (such as `us-central1-a`), the cluster will be a zonal cluster with
-          a single cluster master. If you specify a region (such as `us-west1`),
-          the cluster will be a regional cluster with multiple masters spread
-          across zones in the region, and with default node locations in those zones as well.
+          created, as well as the default node location.
+          If you specify a zone (such as `us-central1-a`), the cluster will be
+          a zonal cluster with a single cluster master.
+
+          If you specify a region (such as `us-west1`), the cluster will be a
+          regional cluster with multiple masters spread across zones in the
+          region, and with default node locations in those zones as well.
 
           For the differences between zonal and regional clusters, please see
           https://cloud.google.com/kubernetes-engine/docs/concepts/types-of-clusters
@@ -117,16 +124,17 @@ section {
         type        = string
         description = <<-END
           The name or `self_link` of the Google Compute Engine network to which
-          the cluster is connected. For Shared VPC, set this to the self link of
-          the shared network.
+          the cluster is connected.
+
+          **Note:** For Shared VPC, set this to the self link of the shared network.
         END
       }
 
       variable "subnetwork" {
         type        = string
         description = <<-END
-          The name or `self_link` of the Google Compute Engine subnetwork in which
-          the cluster's instances are launched.
+          The name or `self_link` of the Google Compute Engine subnetwork in
+          which the cluster's instances are launched.
         END
       }
 
@@ -135,7 +143,9 @@ section {
         default     = "VPC_NATIVE"
         description = <<-END
           Determines whether alias IPs or routes will be used for pod IPs in
-          the cluster. Options are `VPC_NATIVE` or `ROUTES`. `VPC_NATIVE`
+          the cluster.
+
+          Options are `VPC_NATIVE` or `ROUTES`. `VPC_NATIVE`
           enables IP aliasing, and requires the `ip_allocation_policy` block to
           be defined.
 
@@ -188,8 +198,8 @@ section {
       }
 
       variable "ip_allocation_policy" {
-        type = object(ip_allocation_policy)
-        description = <<-END
+        type           = object(ip_allocation_policy)
+        description    = <<-END
           Configuration of cluster IP allocation for VPC-native clusters.
 
           **Note:** This field will only work for VPC-native clusters.
@@ -268,8 +278,8 @@ section {
       }
 
       variable "master_authorized_networks_config" {
-        type = object(master_authorized_networks_config)
-        description = <<-END
+        type           = object(master_authorized_networks_config)
+        description    = <<-END
           Configuration for handling external access control plane of the cluster.
         END
         readme_example = <<-END
@@ -314,8 +324,7 @@ section {
         type        = bool
         default     = false
         description = <<-END
-          If enabled, Vertical Pod Autoscaling automatically adjusts the
-          resources of pods controlled by it.
+          Whether to enable vertical Pod autoscaling in your cluster.
 
           For details please see https://cloud.google.com/kubernetes-engine/docs/concepts/verticalpodautoscaler
         END
@@ -325,7 +334,7 @@ section {
         type        = bool
         default     = true
         description = <<-END
-          Whether to enable orizontal Pod Autoscaling addon,
+          Whether to enable horizontal Pod Autoscaling addon,
           which increases or decreases the number of replica pods a
           replication controller has based on the resource usage of the existing pods.
 
@@ -339,7 +348,7 @@ section {
         description = <<-END
           Whether to enable the the HTTP (L7) load balancing controller addon,
           which makes it easy to set up HTTP load balancers for services in a cluster..
-          
+
           For details please https://cloud.google.com/kubernetes-engine/docs/concepts/ingress
         END
       }
@@ -366,8 +375,8 @@ section {
       }
 
       variable "network_policy" {
-        type        = object(network_policy)
-        description = <<-END
+        type           = object(network_policy)
+        description    = <<-END
           Configuration options for the network policy addon.
           Can only be used if the network policy addon is enabled
           by enabling `addon_network_policy_config`.
@@ -389,7 +398,7 @@ section {
 
         attribute "provider" {
           type        = string
-					default     = "CALICO"
+          default     = "CALICO"
           description = <<-END
             The selected network policy provider.
           END
@@ -402,7 +411,7 @@ section {
         description = <<-END
           Whether to enable the Filestore CSI driver addon, which allows the
           usage of filestore instance as volumes.
-          
+
           For details please see https://cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/filestore-csi-driver
         END
       }
@@ -419,8 +428,8 @@ section {
         END
 
         attribute "daily_maintenance_window" {
-          type        = object(daily_maintenance_window)
-          description = <<-END
+          type           = object(daily_maintenance_window)
+          description    = <<-END
             Time window specified for daily maintenance operations.
 
             For details please see https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#daily_maintenance_window
@@ -444,10 +453,10 @@ section {
         }
 
         attribute "recurring_window" {
-          type        = object(recurring_window)
-          description = <<-END
+          type           = object(recurring_window)
+          description    = <<-END
             Time window specified for recurring maintenance operations.
-           
+
             For details please see https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#recurring_window
           END
           readme_example = <<-END
@@ -489,8 +498,8 @@ section {
         }
 
         attribute "maintenance_exclusion" {
-          type        = list(maintenance_exclusion)
-          description = <<-END
+          type           = list(maintenance_exclusion)
+          description    = <<-END
             Exceptions to maintenance window. Non-emergency maintenance should
             not occur in these windows. A cluster can have up to three
             maintenance exclusions at a time.
@@ -549,7 +558,8 @@ section {
         type        = string
         description = <<-END
           The ID of a BigQuery Dataset for using BigQuery as the destination of
-          resource usage export.
+          resource usage export. Needs to be configured when using egress metering
+          and/or resource consumption metering.
         END
       }
 
@@ -581,96 +591,6 @@ section {
 
           For details please see https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-usage-metering
         END
-      }
-
-      variable "cluster_autoscaling" {
-        type        = object(cluster_autoscaling)
-				default     = false
-        description = <<-END
-          Cluster autoscaling configuration. For details please see
-          https://cloud.google.com/kubernetes-engine/docs/concepts/cluster-autoscaler
-        END
-
-        attribute "enabled" {
-          type        = bool
-          default     = false
-          description = <<-END
-            Whether node auto-provisioning is enabled. Resource limits for cpu
-            and memory must be defined to enable node auto-provisioning.
-          END
-        }
-
-        attribute "cpu" {
-          type        = object(cpu)
-          description = <<-END
-            Global constraints for CPU machine resources in the cluster.
-            Configuring this is required if node auto-provisioning is enabled.
-            These limits will apply to node pool autoscaling in addition to
-            node auto-provisioning.
-          END
-
-          attribute "minimum" {
-            type        = number
-            description = <<-END
-              Minimum amount of CPU resources in the cluster.
-            END
-          }
-
-          attribute "maximum" {
-            type        = number
-            description = <<-END
-              Maximum amount of CPU resources in the cluster.
-            END
-          }
-        }
-
-        attribute "memory" {
-          type        = object(memory)
-          description = <<-END
-            Global constraints for Memory resources in the cluster. Configuring
-            this is required if node auto-provisioning is enabled. These limits
-            will apply to node pool autoscaling in addition to node auto-provisioning.
-          END
-
-          attribute "minimum" {
-            type        = number
-            description = <<-END
-              Minimum amount of memory resources in the cluster.
-            END
-          }
-
-          attribute "maximum" {
-            type        = number
-            description = <<-END
-              Maximum amount of memory resources in the cluster.
-            END
-          }
-        }
-
-        attribute "auto_provisioning_defaults" {
-          type        = object(auto_provisioning_default)
-          description = <<-END
-            Contains defaults for a node pool created by NAP.
-          END
-
-          attribute "oauth_scopes" {
-            type        = list(string)
-            description = <<-END
-              Scopes that are used by NAP when creating node pools. Use the
-              https://www.googleapis.com/auth/cloud-platform scope to grant
-              access to all APIs. It is recommended that you set
-              `service_account` to a non-default service account and grant IAM
-              roles to that service account for only the resources that it needs.
-            END
-          }
-
-          attribute "service_account" {
-            type        = string
-            description = <<-END
-              The Google Cloud Platform Service Account to be used by the node VMs.
-            END
-          }
-        }
       }
 
       variable "logging_enable_components" {
@@ -716,6 +636,8 @@ section {
         description = <<-END
           The GCE resource labels (a map of key/value pairs) to be applied to
           the cluster.
+
+          For details please see https://cloud.google.com/kubernetes-engine/docs/how-to/creating-managing-labels
         END
       }
 
@@ -724,6 +646,7 @@ section {
         default     = 110
         description = <<-END
           The maximum number of pods to schedule per node.
+          GKE has a hard limit of 110 Pods per node.
         END
       }
 
@@ -732,7 +655,12 @@ section {
         default     = false
         description = <<-END
           Whether Intra-node visibility is enabled for this cluster.
-          This makes same node pod to pod traffic visible for VPC network.
+          Intranode visibility configures networking on each node in the
+          cluster so that traffic sent from one Pod to another Pod is
+          processed by the cluster's Virtual Private Cloud (VPC) network,
+          even if the Pods are on the same node.
+
+          For details please see https://cloud.google.com/kubernetes-engine/docs/how-to/intranode-visibility
         END
       }
 
@@ -793,6 +721,7 @@ section {
         default     = true
         description = <<-END
           Whether to enable Shielded Nodes features on all nodes in this cluster.
+          For details please see https://cloud.google.com/kubernetes-engine/docs/concepts/release-channels
         END
       }
 

--- a/main.tf
+++ b/main.tf
@@ -79,39 +79,6 @@ resource "google_container_cluster" "cluster" {
     }
   }
 
-  # --------------------------------------------------------------------------------------------------------------------
-  # Node auto-provisioning
-  # --------------------------------------------------------------------------------------------------------------------
-
-  dynamic "cluster_autoscaling" {
-    for_each = var.cluster_autoscaling != null ? [var.cluster_autoscaling] : []
-
-    content {
-      enabled = try(cluster_autoscaling.value.enabled, false)
-
-      resource_limits {
-        resource_type = "cpu"
-        minimum       = try(cluster_autoscaling.value.cpu.minimum, null)
-        maximum       = try(cluster_autoscaling.value.cpu.maximum, null)
-      }
-
-      resource_limits {
-        resource_type = "memory"
-        minimum       = try(cluster_autoscaling.value.memory.minimum, null)
-        maximum       = try(cluster_autoscaling.value.memory.maximum, null)
-      }
-
-      dynamic "auto_provisioning_defaults" {
-        for_each = try([cluster_autoscaling.value.auto_provisioning_defaults], [])
-
-        content {
-          oauth_scopes    = try(auto_provisioning_defaults.value.oauth_scopes, null)
-          service_account = try(auto_provisioning_defaults.value.service_account, null)
-        }
-      }
-    }
-  }
-
   dynamic "vertical_pod_autoscaling" {
     for_each = var.enable_vertical_pod_autoscaling != null ? [1] : []
 
@@ -221,9 +188,10 @@ resource "google_container_cluster" "cluster" {
   # REMOVE DEFAULT NODE-POOL AFTER INITIAL CREATION
   #
   # We create the smallest possible default node-pool and delete it right away
-  # there is no way not to create the default node pool.
-  # node pools should be created using the terraform-google-gke-node-pool module
-  # for regional clusters that will create 1 node in each zone of the region
+  # since there is no way not to create the default node pool.
+  # Node pools should be created using the terraform-google-gke-node-pool module
+  #
+  # For details please see https://github.com/mineiros-io/terraform-google-gke-node-pool
   # --------------------------------------------------------------------------------------------------------------------
 
   initial_node_count       = 1

--- a/test/unit-complete/main.tf
+++ b/test/unit-complete/main.tf
@@ -146,25 +146,6 @@ module "test" {
   }
 
   # cluster_ipv4_cidr = local.subnet.secondary_ip_ranges.pods.cidr_range
-  cluster_autoscaling = {
-    enabled = true
-    cpu = {
-      minimum = 1
-      maximum = 4
-    }
-    memory = {
-      minimum = 4
-      maximum = 16
-    }
-    auto_provisioning_defaults = {
-      # Google recommends custom service accounts that have cloud-platform scope and permissions granted via IAM Roles.
-      service_account = module.service-account.precomputed_email
-      oauth_scopes = [
-        "https://www.googleapis.com/auth/cloud-platform"
-      ]
-    }
-  }
-
   rbac_security_identity_group = "gke-security-groups@mineiros.io"
 
   default_max_pods_per_node            = 110

--- a/variables.tf
+++ b/variables.tf
@@ -67,38 +67,6 @@ variable "cluster_ipv4_cidr" {
   default     = null
 }
 
-variable "cluster_autoscaling" {
-  type = any
-  # type = object({
-  #   # (Required) Whether node auto-provisioning is enabled. Resource limits for cpu and memory must be defined to enable node auto-provisioning.
-  #   enabled = bool
-  #   # (Optional) Configuring the CPU thresholds is required if node auto-provisioning is enabled. These limits will apply to node pool autoscaling in addition to node auto-provisioning.
-  #   cpu = optional(object({
-  #     # (Optional) Minimum amount of the resource in the cluster.
-  #     minimum = optional(number)
-  #     # (Optional) Maximum amount of the resource in the cluster.
-  #     maximum = optional(number)
-  #   }))
-  #   # (Optional) Configuring memory thresholds is required if node auto-provisioning is enabled. These limits will apply to node pool autoscaling in addition to node auto-provisioning.
-  #   memory = optional(object({
-  #     # (Optional) Minimum amount of the resource in the cluster.
-  #     minimum = optional(number)
-  #     # (Optional) Maximum amount of the resource in the cluster.
-  #     maximum = optional(number)
-  #   }))
-  #   # (Optional) Contains defaults for a node pool created by NAP.
-  #   auto_provisioning_defaults = optional(object({
-  #     # (Optional) Scopes that are used by NAP when creating node pools. Use the "https://www.googleapis.com/auth/cloud-platform" scope to grant access to all APIs. It is recommended that you set `service_account` to a non-default service account and grant IAM roles to that service account for only the resources that it needs.
-  #     # Note: `monitoring`.write is always enabled regardless of user input. `monitoring` and `logging`,.`write` may also be enabled depending on the values for `monitoring_service` and `logging_service`.
-  #     oauth_scopes = optional(set(string))
-  #     # (Optional) The Google Cloud Platform Service Account to be used by the node VMs.
-  #     service_account = optional(string)
-  #   }))
-  # })
-  description = "(Optional) Cluster autoscaling configuration. For details please see: https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1beta1/projects.locations.clusters#clusterautoscaling"
-  default     = null
-}
-
 variable "database_encryption_key_name" {
   type        = string
   description = "(Optional) The name of a CloudKMS key to enable application-layer secrets encryption settings. If non-null the state will be set to: ENCRYPTED else DECRYPTED."


### PR DESCRIPTION
- Removed `cluster_autoscaling` as it only applies to a clusters default node pool which are not supported by this module.
